### PR TITLE
Fix: 투두 페이지 요청될 때 토큰이 있어야 데이터 요청하도록 수정

### DIFF
--- a/src/pages/ToDo.jsx
+++ b/src/pages/ToDo.jsx
@@ -28,7 +28,9 @@ const ToDo = () => {
   }, [localStorage.getItem('token')]);
 
   useEffect(() => {
-    fetchAndSetTodo();
+    if (localStorage.getItem('token')) {
+      fetchAndSetTodo();
+    }
   }, []);
 
   return (


### PR DESCRIPTION
로그인 하지 않은 상태로 /todo에 접근 시 alert이 뜨며 로그인페이지로 리다이렉트되긴 하지만
투두 페이지에서 get요청이 이루어져서 에러 alert이 하나 더 나타납니다.
투두 페이지에서 get요청이 이루어지기 전에 토큰을 확인하고, 토큰이 있어야 요청을 하도록 수정했습니다.